### PR TITLE
added proj support

### DIFF
--- a/v3.1/Dockerfile
+++ b/v3.1/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM debian:bullseye-slim
 
-ENV MAPNIK_VERSION v3.1.0
+ENV MAPNIK_VERSION=v3.1.0
 
 ENV BUILD_DEPENDENCIES="build-essential \
     ca-certificates \
@@ -33,7 +33,6 @@ ENV BUILD_DEPENDENCIES="build-essential \
     libicu-dev \
     libjpeg-dev \
     libpq-dev  \
-    libproj-dev \
     librasterlite2-dev \
     libsqlite3-dev \
     libtiff-dev \
@@ -53,7 +52,6 @@ ENV DEPENDENCIES="libboost-filesystem1.74.0 \
     libicu67 \
     libjpeg62-turbo \
     libpq5 \
-    libproj19 \
     librasterlite2-1 \
     libsqlite3-0 \
     libtiff5 \
@@ -61,11 +59,23 @@ ENV DEPENDENCIES="libboost-filesystem1.74.0 \
     libwebp6  \
     libwebpdemux2 \
     libwebpmux3 \
-    python"
+    wget \
+    cmake \
+    python-is-python3 "
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         $BUILD_DEPENDENCIES $DEPENDENCIES \
+    && cd /root \
+    && wget 'https://download.osgeo.org/proj/proj-5.2.0.tar.gz' \
+    && tar -zxf proj-5.2.0.tar.gz \ 
+    && cd proj-5.2.0 \ 
+    && mkdir build \
+    && cd build \
+    && cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr .. \
+    && cmake --build . \
+    && cmake --build . --target install \
+    && cd /root \
     && git clone https://github.com/mapnik/mapnik.git \
     && cd mapnik \
     && git checkout $MAPNIK_VERSION \
@@ -77,4 +87,8 @@ RUN apt-get update \
     && rm -r mapnik \
     && apt-get autoremove -y --purge $BUILD_DEPENDENCIES \
     && rm -rf /var/lib/apt/lists/* \
-    && ln -s /usr/local/lib/mapnik /usr/lib/mapnik
+    && ln -s /usr/local/lib/mapnik /usr/lib/mapnik \
+    && ln -s /usr/local/lib/mapnik /usr/local/lib/plugins 
+
+#WORKDIR /usr/local/lib
+#ENTRYPOINT ["mapnik-render"]


### PR DESCRIPTION
Fixed ENV for MAPNIK_VERSION and added support for proj (default proj from Debian was too far ahead, mapnik v3.1 needs proj v5.xx)